### PR TITLE
Add Procfile that lets running the .NET Core project automatically

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+# This file lets NBG Developer Studio know how to run your .NET Core web server
+web: export ASPNETCORE_URLS="http://+:$PORT" && dotnet restore && dotnet build && dotnet publish && dotnet /mnt/project/bin/Debug/netcoreapp2.0/netcoresb.dll


### PR DESCRIPTION
This should make this repo work out of the box in NBG Developer Studio.

I added a Procfile that install dependencies, builds the project and then runs the web server on the appropriate port (defined by the `PORT` environment variable).

---

The configuration needed is based on how SourceLair handles it's Web Servers ([docs](https://help.sourcelair.com/webserver/)).